### PR TITLE
fix: add .gitignore to skip node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Automated tools and editors often evaluate the filesystem for changes vs git. 

Since there are ~24K files in node_modules, this is considerably slow for no reason.